### PR TITLE
Add MONKY local launcher, server updates, and dashboard enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,20 +75,67 @@
       .sidebar .brand {
         display: flex;
         align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        width: 100%;
+      }
+
+      .brand-logo {
+        display: flex;
+        align-items: center;
         gap: 12px;
       }
 
-      .sidebar .brand svg {
+      .brand-logo svg {
         width: 36px;
         height: 36px;
         flex-shrink: 0;
       }
 
-      .sidebar .brand h1 {
+      .brand-logo h1 {
         font-size: 1.1rem;
         font-weight: 700;
         letter-spacing: 0.08em;
         margin: 0;
+      }
+
+      .avatar-button {
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(79, 128, 255, 0.12);
+        border-radius: 50%;
+        width: 46px;
+        height: 46px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        position: relative;
+        overflow: hidden;
+        transition: transform 0.2s ease, border-color 0.2s ease;
+      }
+
+      .avatar-button:hover {
+        transform: translateY(-2px);
+        border-color: rgba(64, 255, 183, 0.4);
+      }
+
+      .avatar-button img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: none;
+      }
+
+      .avatar-button span {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: var(--text-100);
+        background: rgba(79, 128, 255, 0.24);
       }
 
       .tab-list {
@@ -121,6 +168,13 @@
         justify-content: center;
         background: rgba(255, 255, 255, 0.04);
         font-size: 0.9rem;
+        overflow: hidden;
+      }
+
+      .tab-button span.icon img {
+        width: 20px;
+        height: 20px;
+        display: block;
       }
 
       .tab-button.active,
@@ -191,6 +245,47 @@
         display: flex;
         align-items: center;
         gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .server-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        background: rgba(40, 51, 73, 0.18);
+        border: 1px solid rgba(255, 255, 255, 0.06);
+        border-radius: 999px;
+        padding: 8px 14px;
+        font-size: 0.85rem;
+        color: var(--text-200);
+      }
+
+      .server-status .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--warning);
+        box-shadow: 0 0 12px rgba(255, 255, 255, 0.1);
+      }
+
+      .server-status[data-status="online"] {
+        color: var(--accent);
+        border-color: rgba(64, 255, 183, 0.4);
+      }
+
+      .server-status[data-status="online"] .status-dot {
+        background: var(--accent);
+        box-shadow: 0 0 12px rgba(64, 255, 183, 0.4);
+      }
+
+      .server-status[data-status="offline"] {
+        color: #ffb4b4;
+        border-color: rgba(255, 95, 95, 0.4);
+      }
+
+      .server-status[data-status="offline"] .status-dot {
+        background: var(--danger);
+        box-shadow: 0 0 12px rgba(255, 95, 95, 0.4);
       }
 
       .ghost-button,
@@ -526,6 +621,21 @@
         overflow-x: auto;
       }
 
+      .server-meta {
+        display: grid;
+        gap: 8px;
+        font-size: 0.85rem;
+        color: var(--text-200);
+      }
+
+      .server-meta code {
+        font-family: "JetBrains Mono", "Fira Code", monospace;
+        font-size: 0.85rem;
+        background: rgba(18, 24, 38, 0.8);
+        padding: 4px 8px;
+        border-radius: 8px;
+      }
+
       .pill {
         display: inline-flex;
         align-items: center;
@@ -604,6 +714,29 @@
         color: var(--text-200);
         padding: 6px 10px;
         cursor: pointer;
+      }
+
+      .modal .avatar-preview {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(7, 9, 15, 0.8);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 18px;
+        padding: 20px;
+        min-height: 140px;
+      }
+
+      .modal .avatar-preview img {
+        max-width: 160px;
+        max-height: 160px;
+        border-radius: 18px;
+        object-fit: cover;
+      }
+
+      .avatar-preview-empty {
+        color: var(--muted);
+        font-size: 0.9rem;
       }
 
       form.settings-grid {
@@ -690,20 +823,26 @@
     <div class="app-shell">
       <aside class="sidebar">
         <div class="brand">
-          <svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="12" y="12" width="96" height="96" rx="26" stroke="#4f80ff" stroke-width="6" fill="rgba(79,128,255,0.1)" />
-            <path d="M40 62c12-24 32-24 44 0" stroke="#40ffb7" stroke-width="6" stroke-linecap="round" />
-            <circle cx="60" cy="48" r="8" stroke="#4f80ff" stroke-width="6" />
-            <path d="M40 78h40" stroke="#4f80ff" stroke-width="6" stroke-linecap="round" />
-          </svg>
-          <h1>MONKY OPS</h1>
+          <div class="brand-logo">
+            <svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect x="12" y="12" width="96" height="96" rx="26" stroke="#4f80ff" stroke-width="6" fill="rgba(79,128,255,0.1)" />
+              <path d="M40 62c12-24 32-24 44 0" stroke="#40ffb7" stroke-width="6" stroke-linecap="round" />
+              <circle cx="60" cy="48" r="8" stroke="#4f80ff" stroke-width="6" />
+              <path d="M40 78h40" stroke="#4f80ff" stroke-width="6" stroke-linecap="round" />
+            </svg>
+            <h1>MONKY OPS</h1>
+          </div>
+          <button class="avatar-button" id="avatarButton" title="Edit avatar">
+            <img id="sidebarAvatarImage" alt="User avatar" />
+            <span id="avatarFallback">YOU</span>
+          </button>
         </div>
         <nav class="tab-list">
-          <button class="tab-button active" data-tab="chat"><span class="icon">💬</span>Chat</button>
-          <button class="tab-button" data-tab="lab"><span class="icon">🧪</span>Laboratory</button>
-          <button class="tab-button" data-tab="notes"><span class="icon">📓</span>Notes / Tasks</button>
-          <button class="tab-button" data-tab="dev"><span class="icon">🛠️</span>Dev Tools</button>
-          <button class="tab-button" data-tab="future"><span class="icon">🛰️</span>Future</button>
+          <button class="tab-button active" data-tab="chat"><span class="icon" data-icon="chat" data-fallback="💬"></span>Chat</button>
+          <button class="tab-button" data-tab="lab"><span class="icon" data-icon="lab" data-fallback="🧪"></span>Laboratory</button>
+          <button class="tab-button" data-tab="notes"><span class="icon" data-icon="notes" data-fallback="📓"></span>Notes / Tasks</button>
+          <button class="tab-button" data-tab="dev"><span class="icon" data-icon="dev" data-fallback="🛠️"></span>Dev Tools</button>
+          <button class="tab-button" data-tab="future"><span class="icon" data-icon="future" data-fallback="🛰️"></span>Future</button>
         </nav>
         <div class="sidebar-footer">
           <div class="pill">MONKY Darkline</div>
@@ -716,13 +855,13 @@
           <div class="status-clusters">
             <div class="status-card">
               <h3>MODE</h3>
-              <strong id="statusMode">Initializing…</strong>
+              <strong id="statusMode">Initializing...</strong>
               <span class="muted">Provider &amp; model routing</span>
             </div>
             <div class="status-card">
               <h3>RAG INDEX</h3>
               <strong id="statusRag">Unknown</strong>
-              <span class="muted" id="statusRagDetail">Checking…</span>
+              <span class="muted" id="statusRagDetail">Checking...</span>
             </div>
             <div class="status-card">
               <h3>SESSION</h3>
@@ -731,6 +870,10 @@
             </div>
           </div>
           <div class="toolbar-actions">
+            <div class="server-status" id="serverStatusIndicator" data-status="offline">
+              <span class="status-dot"></span>
+              <span class="status-label">Starting...</span>
+            </div>
             <button id="refreshRag" class="ghost-button">Refresh RAG</button>
             <button id="clearThread" class="ghost-button">Clear Thread</button>
             <button id="settingsButton" class="pill-button primary">Settings</button>
@@ -829,6 +972,21 @@
           <section class="tab-panel" id="tab-dev">
             <div class="dev-tools">
               <div class="card">
+                <div class="section-title">Server / Storage Utility</div>
+                <div class="server-meta">
+                  <div>API base: <code id="devApiBase">—</code></div>
+                  <div>Vector index: <code id="devVectorDir">—</code></div>
+                  <div>Export dir: <code id="devExportDir">—</code></div>
+                  <div>RAG documents: <span id="devDocCount">—</span></div>
+                </div>
+                <div class="toolbar-actions" style="flex-wrap:wrap">
+                  <button id="devPing" class="ghost-button">Ping</button>
+                  <button id="devShowExport" class="ghost-button">Open Export Folder</button>
+                  <button id="devReloadRag" class="ghost-button">Reload RAG Stats</button>
+                </div>
+                <pre id="devServerResult">—</pre>
+              </div>
+              <div class="card">
                 <div class="section-title">Chat payload tester</div>
                 <textarea id="devChatPayload" rows="8">{
   "messages": [
@@ -872,6 +1030,27 @@
       </main>
     </div>
 
+    <div class="modal-overlay" id="avatarModal">
+      <div class="modal">
+        <header>
+          <h2>Edit Avatar</h2>
+          <button class="close" id="avatarClose">Close</button>
+        </header>
+        <div class="avatar-preview" id="avatarPreview">
+          <div class="avatar-preview-empty">No avatar selected</div>
+        </div>
+        <div class="two-col">
+          <label class="label" style="grid-column:1/-1">
+            Choose image
+            <input type="file" id="avatarInput" accept="image/*" />
+          </label>
+        </div>
+        <div class="toolbar-actions" style="justify-content:flex-end">
+          <button type="button" class="ghost-button" id="avatarRemove">Remove</button>
+          <button type="button" class="pill-button primary" id="avatarSave">Save</button>
+        </div>
+      </div>
+    </div>
     <div class="modal-overlay" id="settingsModal">
       <div class="modal">
         <header>
@@ -932,18 +1111,24 @@
         isStreaming: false,
         labMatches: [],
         editingNoteId: null,
+        serverOnline: false,
+        healthInterval: null,
+        ragStats: { hasIndex: false, docCount: 0, indexPath: "", error: null },
+        iconsAvailable: false,
       };
 
       const storage = {
         settings: "monky.settings",
         notes: "monky.notes",
         thread: "monky.thread",
+        avatar: "monky.avatarBase64",
       };
 
       const el = (id) => document.getElementById(id);
 
       const toast = (message, timeout = 2600) => {
         const node = el("toast");
+        if (!node) return;
         node.textContent = message;
         node.classList.add("visible");
         setTimeout(() => node.classList.remove("visible"), timeout);
@@ -997,16 +1182,112 @@
         return html;
       };
 
+      const applyIcons = () => {
+        const nodes = document.querySelectorAll('[data-icon]');
+        nodes.forEach((node) => {
+          const fallback = node.dataset.fallback || "";
+          if (state.iconsAvailable) {
+            const name = node.dataset.icon || "icon";
+            node.innerHTML = `<img src="/icons/${name}.svg" alt="${name} icon" />`;
+          } else {
+            node.textContent = fallback;
+          }
+        });
+      };
+
+      const getStoredAvatar = () => localStorage.getItem(storage.avatar) || "";
+      const currentAvatarSource = () => getStoredAvatar() || state.env.USER_AVATAR_URL || "";
+
+      const updateAvatarDisplay = () => {
+        const image = el("sidebarAvatarImage");
+        const fallback = el("avatarFallback");
+        const src = currentAvatarSource();
+        if (image && fallback) {
+          if (src) {
+            image.src = src;
+            image.style.display = "block";
+            fallback.style.display = "none";
+          } else {
+            image.removeAttribute("src");
+            image.style.display = "none";
+            fallback.style.display = "flex";
+          }
+        }
+      };
+
+      const avatarState = { dataUrl: "" };
+
+      const updateAvatarPreview = () => {
+        const preview = el("avatarPreview");
+        if (!preview) return;
+        const src = avatarState.dataUrl || state.env.USER_AVATAR_URL || "";
+        if (src) {
+          preview.innerHTML = `<img src="${src}" alt="Avatar preview" />`;
+        } else {
+          preview.innerHTML = "<div class=\"avatar-preview-empty\">No avatar selected</div>";
+        }
+      };
+
+      const openAvatarModal = () => {
+        const modal = el("avatarModal");
+        if (!modal) return;
+        avatarState.dataUrl = getStoredAvatar() || "";
+        updateAvatarPreview();
+        const input = el("avatarInput");
+        if (input) input.value = "";
+        modal.classList.add("active");
+      };
+
+      const closeAvatarModal = () => {
+        const modal = el("avatarModal");
+        if (!modal) return;
+        modal.classList.remove("active");
+        const input = el("avatarInput");
+        if (input) input.value = "";
+      };
+
+      const handleAvatarFileChange = (event) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          avatarState.dataUrl = typeof reader.result === "string" ? reader.result : "";
+          updateAvatarPreview();
+        };
+        reader.readAsDataURL(file);
+      };
+
+      const saveAvatarOverride = () => {
+        const dataUrl = avatarState.dataUrl;
+        if (dataUrl && dataUrl.startsWith("data:")) {
+          localStorage.setItem(storage.avatar, dataUrl);
+          toast("Avatar updated");
+        } else {
+          localStorage.removeItem(storage.avatar);
+          toast("Avatar cleared");
+        }
+        updateAvatarDisplay();
+        closeAvatarModal();
+      };
+
+      const removeAvatarOverride = () => {
+        localStorage.removeItem(storage.avatar);
+        avatarState.dataUrl = "";
+        updateAvatarPreview();
+        updateAvatarDisplay();
+        toast("Avatar cleared");
+      };
+
       const renderMessages = () => {
         const container = el("chatMessages");
+        if (!container) return;
         container.innerHTML = "";
-        state.messages.forEach((message, index) => {
+        state.messages.forEach((message) => {
           const node = el("messageTemplate").content.firstElementChild.cloneNode(true);
           node.classList.add(message.role);
           node.querySelector(".avatar").textContent = message.role === "assistant" ? "M" : message.role === "system" ? "SYS" : "YOU";
           const bubble = node.querySelector(".bubble");
           bubble.innerHTML = renderMarkdown(message.content || "");
-
           const meta = document.createElement("div");
           meta.className = "bubble-meta";
           const copy = document.createElement("button");
@@ -1027,7 +1308,7 @@
           }
           if (message.role === "assistant" && message.streaming) {
             const pulse = document.createElement("div");
-            pulse.textContent = "Streaming…";
+            pulse.textContent = "Streaming...";
             meta.appendChild(pulse);
           }
 
@@ -1057,35 +1338,92 @@
         return await response.json();
       };
 
+      const updateServerStatusIndicator = (online, label) => {
+        const indicator = el("serverStatusIndicator");
+        if (!indicator) return;
+        indicator.dataset.status = online ? "online" : "offline";
+        const node = indicator.querySelector(".status-label");
+        if (node) {
+          node.textContent = label || (online ? "✅ Online" : "❌ Offline");
+        }
+      };
+
+      const checkServerHealth = async () => {
+        try {
+          const response = await fetch("/health");
+          if (!response.ok) throw new Error(await response.text());
+          const data = await response.json();
+          const ok = data.ok === true;
+          state.serverOnline = ok;
+          updateServerStatusIndicator(ok, ok ? "✅ Online" : "❌ Offline");
+        } catch (err) {
+          state.serverOnline = false;
+          updateServerStatusIndicator(false, "❌ Offline");
+        }
+      };
+
+      const startHealthPolling = () => {
+        if (state.healthInterval) return;
+        updateServerStatusIndicator(false, "Checking...");
+        checkServerHealth();
+        state.healthInterval = setInterval(checkServerHealth, 3000);
+      };
+
+      const updateServerUtilities = () => {
+        const apiBase = state.env.API_BASE_URL || window.location.origin;
+        const vectorDir = state.env.VECTOR_INDEX_DIR || "—";
+        const exportDir = state.env.DESKTOP_EXPORT_DIR || "—";
+        const stats = state.ragStats || { hasIndex: false, docCount: 0, error: null };
+        const docLabel = stats.hasIndex
+          ? `${stats.docCount} docs`
+          : stats.error
+          ? `⚠️ ${stats.error}`
+          : "No index";
+        const apiNode = el("devApiBase");
+        const vecNode = el("devVectorDir");
+        const expNode = el("devExportDir");
+        const docNode = el("devDocCount");
+        if (apiNode) apiNode.textContent = apiBase;
+        if (vecNode) vecNode.textContent = vectorDir;
+        if (expNode) expNode.textContent = exportDir;
+        if (docNode) docNode.textContent = docLabel;
+      };
+
       const loadEnv = async () => {
         try {
           const data = await fetchJSON("/env");
           state.env = data;
+          state.iconsAvailable = Boolean(data.ICONS_AVAILABLE && data.ICONS_DIR);
+          applyIcons();
           const saved = loadSettings();
-          const provider = saved.provider || (data.GENESIS_API_KEY ? "genesis" : "openrouter");
+          const provider = saved.provider || (data.GENESIS_READY ? "genesis" : data.OPENROUTER_READY ? "openrouter" : "genesis");
           state.provider = provider;
-          state.model = saved.model || data.OPENROUTER_MODEL || "";
-          state.ragEnabled = Boolean(saved.ragEnabled);
+          state.model = saved.model || data.DEFAULT_MODEL || data.OPENROUTER_MODEL || "";
+          state.ragEnabled = saved.ragEnabled === undefined ? false : Boolean(saved.ragEnabled);
           state.stream = saved.stream !== false;
           el("ragToggle").checked = state.ragEnabled;
           el("streamToggle").checked = state.stream;
-          el("envStatus").textContent = `Genesis ${data.GENESIS_API_KEY ? "ready" : "—"} • OpenRouter ${data.OPENROUTER_API_KEY ? "ready" : "—"}`;
-          el("settingsGenesisKey").value = saved.genesisKey || data.GENESIS_API_KEY || "";
-          el("settingsOpenRouterKey").value = saved.openRouterKey || data.OPENROUTER_API_KEY || "";
+          el("envStatus").textContent = `Genesis ${data.GENESIS_READY ? "ready" : "—"} • OpenRouter ${data.OPENROUTER_READY ? "ready" : "—"}`;
+          el("settingsGenesisKey").value = saved.genesisKey || "";
+          el("settingsOpenRouterKey").value = saved.openRouterKey || "";
           el("settingsGenesisBase").value = saved.genesisBase || data.GENESIS_BASE_URL || "";
-          el("settingsDefaultModel").value = saved.model || data.OPENROUTER_MODEL || "";
-          el("settingsEmbeddingModel").value = saved.embeddingModel || "text-embedding-3-small";
+          el("settingsDefaultModel").value = saved.model || data.DEFAULT_MODEL || data.OPENROUTER_MODEL || "";
+          el("settingsEmbeddingModel").value = saved.embeddingModel || data.EMBEDDING_MODEL || "text-embedding-3-small";
           updateStatusMode();
+          updateAvatarDisplay();
+          updateServerUtilities();
           populateProviderSelect(provider);
           await Promise.all([loadModels(provider), loadAssistants(provider)]);
+          startHealthPolling();
         } catch (err) {
           console.error(err);
           el("envStatus").textContent = "Env unavailable";
+          updateServerStatusIndicator(false, "❌ Offline");
         }
       };
-
       const populateProviderSelect = (selected) => {
         const select = el("providerSelect");
+        if (!select) return;
         const options = [
           { value: "genesis", label: "Genesis" },
           { value: "openrouter", label: "OpenRouter" },
@@ -1100,6 +1438,7 @@
           const data = await fetchJSON(`/api/models?provider=${provider}`);
           const models = data.data || data.models || [];
           const select = el("modelSelect");
+          if (!select) return;
           select.innerHTML = "";
           models.forEach((model) => {
             const option = document.createElement("option");
@@ -1235,18 +1574,21 @@
       const loadRagStats = async () => {
         try {
           const stats = await fetchJSON("/api/rag/stats");
+          state.ragStats = stats;
           el("labStatus").textContent = stats.hasIndex
             ? `${stats.docCount} documents indexed @ ${stats.indexPath}`
             : stats.error || "No index detected";
           el("statusRag").textContent = stats.hasIndex ? "Online" : "Offline";
           el("statusRagDetail").textContent = stats.hasIndex ? `${stats.docCount} docs` : stats.error || "Missing";
+          updateServerUtilities();
         } catch (err) {
           el("labStatus").textContent = "Unable to load stats";
           el("statusRag").textContent = "Error";
           el("statusRagDetail").textContent = err.message;
+          state.ragStats = { hasIndex: false, docCount: 0, indexPath: "", error: err.message };
+          updateServerUtilities();
         }
       };
-
       const performRagQuery = async (query, k) => {
         const response = await fetchJSON("/api/rag/query", {
           method: "POST",
@@ -1255,9 +1597,10 @@
         });
         state.labMatches = response.matches || [];
         const results = el("labResults");
+        if (!results) return;
         results.innerHTML = "";
         if (!state.labMatches.length) {
-          results.innerHTML = `<div style="grid-column:1/-1;color:var(--muted)">No matches</div>`;
+          results.innerHTML = "<div style=\"grid-column:1/-1;color:var(--muted)\">No matches</div>";
           el("labUseContext").disabled = true;
           return;
         }
@@ -1288,9 +1631,10 @@
       const renderNotes = () => {
         const notes = notesStore.all();
         const grid = el("notesGrid");
+        if (!grid) return;
         grid.innerHTML = "";
         if (!notes.length) {
-          grid.innerHTML = `<div style="grid-column:1/-1;color:var(--muted)">No notes yet</div>`;
+          grid.innerHTML = "<div style=\"grid-column:1/-1;color:var(--muted)\">No notes yet</div>";
           return;
         }
         notes.forEach((note) => {
@@ -1405,7 +1749,6 @@
         saveThread();
         renderMessages();
       };
-
       const loadSavedThread = () => {
         const history = loadThread();
         if (history.length) {
@@ -1501,6 +1844,25 @@
         await loadEnv();
       };
 
+      const handleDevPing = async () => {
+        try {
+          const data = await fetchJSON("/health");
+          el("devServerResult").textContent = JSON.stringify(data, null, 2);
+        } catch (err) {
+          el("devServerResult").textContent = err.message;
+        }
+      };
+
+      const showExportPath = () => {
+        const pathValue = state.env.DESKTOP_EXPORT_DIR || "Unknown";
+        el("devServerResult").textContent = pathValue;
+        toast("Export path ready");
+      };
+
+      const reloadRagFromDev = async () => {
+        await loadRagStats();
+        el("devServerResult").textContent = JSON.stringify(state.ragStats, null, 2);
+      };
       const init = async () => {
         document.querySelectorAll(".tab-button").forEach((button) => button.addEventListener("click", handleTabChange));
         el("sendButton").addEventListener("click", sendChat);
@@ -1541,7 +1903,24 @@
           const file = event.target.files?.[0];
           if (file) importSettings(file);
         });
+        const avatarButton = el("avatarButton");
+        if (avatarButton) avatarButton.addEventListener("click", openAvatarModal);
+        const avatarClose = el("avatarClose");
+        if (avatarClose) avatarClose.addEventListener("click", closeAvatarModal);
+        const avatarInput = el("avatarInput");
+        if (avatarInput) avatarInput.addEventListener("change", handleAvatarFileChange);
+        const avatarSave = el("avatarSave");
+        if (avatarSave) avatarSave.addEventListener("click", saveAvatarOverride);
+        const avatarRemove = el("avatarRemove");
+        if (avatarRemove) avatarRemove.addEventListener("click", removeAvatarOverride);
+        const devPing = el("devPing");
+        if (devPing) devPing.addEventListener("click", handleDevPing);
+        const devShowExport = el("devShowExport");
+        if (devShowExport) devShowExport.addEventListener("click", showExportPath);
+        const devReloadRag = el("devReloadRag");
+        if (devReloadRag) devReloadRag.addEventListener("click", reloadRagFromDev);
 
+        applyIcons();
         loadSavedThread();
         renderNotes();
         await loadEnv();
@@ -1550,5 +1929,6 @@
 
       document.addEventListener("DOMContentLoaded", init);
     </script>
+
   </body>
 </html>

--- a/launch_monky.py
+++ b/launch_monky.py
@@ -1,0 +1,127 @@
+"""Launcher utility for the MONKY local dashboard."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+BASE_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = BASE_DIR / "config.json"
+SERVER_PATH = BASE_DIR / "server.py"
+
+
+def load_config() -> Dict[str, Any]:
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError("config.json missing")
+    with CONFIG_PATH.open("r", encoding="utf-8") as fp:
+        data = json.load(fp) or {}
+    if not isinstance(data, dict):
+        raise ValueError("config.json must contain an object")
+    return data
+
+
+def run_setup_wizard() -> None:
+    wizard = BASE_DIR / "setup_wizard.py"
+    if not wizard.exists():
+        raise FileNotFoundError("setup_wizard.py not found")
+    subprocess.Popen([sys.executable, str(wizard)], cwd=str(BASE_DIR))
+
+
+def pythonw_executable() -> str:
+    if sys.platform.startswith("win"):
+        pythonw = Path(sys.executable).with_name("pythonw.exe")
+        if pythonw.exists():
+            return str(pythonw)
+    return sys.executable
+
+
+def start_server(port: int) -> subprocess.Popen:
+    if not SERVER_PATH.exists():
+        raise FileNotFoundError("server.py not found")
+
+    env = os.environ.copy()
+    env.setdefault("PROXY_HOST", "127.0.0.1")
+    env.setdefault("PROXY_PORT", str(port))
+
+    kwargs: Dict[str, Any] = {
+        "cwd": str(BASE_DIR),
+        "env": env,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+
+    executable = pythonw_executable()
+    args = [executable, str(SERVER_PATH)]
+
+    if sys.platform.startswith("win"):
+        CREATE_NO_WINDOW = 0x08000000
+        DETACHED_PROCESS = 0x00000008
+        kwargs["creationflags"] = CREATE_NO_WINDOW | DETACHED_PROCESS
+        kwargs["close_fds"] = True
+
+    return subprocess.Popen(args, **kwargs)
+
+
+def wait_for_health(port: int, timeout: float = 30.0, process: Optional[subprocess.Popen] = None) -> bool:
+    deadline = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/health"
+    while time.time() < deadline:
+        if process and process.poll() is not None:
+            return False
+        try:
+            req = Request(url, headers={"Accept": "application/json"})
+            with urlopen(req, timeout=5) as response:
+                if 200 <= response.status < 300:
+                    try:
+                        payload = json.load(response)
+                    except json.JSONDecodeError:
+                        payload = {}
+                    if payload.get("ok") is True:
+                        return True
+        except (HTTPError, URLError, OSError):
+            pass
+        time.sleep(1)
+    return False
+
+
+def open_dashboard(port: int) -> None:
+    url = f"http://127.0.0.1:{port}/"
+    webbrowser.open(url, new=1, autoraise=True)
+
+
+def main() -> None:
+    try:
+        config = load_config()
+    except FileNotFoundError:
+        run_setup_wizard()
+        return
+    except Exception as exc:
+        print(f"Failed to read config: {exc}")
+        return
+
+    port = int(config.get("HTTP_PORT", 5000))
+
+    try:
+        process = start_server(port)
+    except Exception as exc:
+        print(f"Failed to start server: {exc}")
+        return
+
+    if wait_for_health(port, timeout=30, process=process):
+        open_dashboard(port)
+    else:
+        print("Server did not become ready within 30 seconds.")
+        if process.poll() is None:
+            process.terminate()
+
+
+if __name__ == "__main__":  # pragma: no cover - script execution
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+requests
+sentence-transformers
+numpy
+faiss-cpu  # optional; MONKY will run without FAISS if unavailable

--- a/server.py
+++ b/server.py
@@ -1,38 +1,146 @@
-"""Flask proxy server for the MONKY dashboard.
-
-This module consolidates the behaviour from the previous proxy server used by
-the project and exposes a compact REST API that powers the single page
-application described in the project brief.  The server exposes the following
-categories of endpoints:
-
-* Configuration helpers (``/env`` and ``/health``)
-* Chat/embeddings/model proxy routes that forward requests to Genesis or
-  OpenRouter
-* Assistant management endpoints (Genesis Assistants v2)
-* RAG helper routes that query a local FAISS index
-
-The implementation intentionally keeps external dependencies to a minimum:
-``Flask`` and ``requests`` are used for HTTP handling, while the FAISS bridge is
-loaded lazily so the application still runs if the optional dependencies are not
-available.  The goal is to provide an offline-friendly tool that can still
-leverage remote models when credentials are available.
-"""
+"""Local Flask proxy server for the MONKY dashboard."""
 
 from __future__ import annotations
 
 import json
 import logging
+import mimetypes
 import os
 from pathlib import Path
 import pickle
-from typing import Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-import requests
+try:  # Prefer ``requests`` when available, fall back to ``urllib`` otherwise.
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback when dependency missing
+    from urllib import error as urllib_error
+    from urllib import parse as urllib_parse
+    from urllib import request as urllib_request
+
+    class _RequestException(Exception):
+        pass
+
+    class _SimpleResponse:
+        """Minimal stand-in for ``requests.Response`` using ``urllib``."""
+
+        def __init__(self, raw_response):
+            self._raw = raw_response
+            self._content: Optional[bytes] = None
+            status = getattr(raw_response, "status", None)
+            if status is None:
+                status = getattr(raw_response, "code", None)
+            if status is None:
+                try:
+                    status = raw_response.getcode()
+                except Exception:  # pragma: no cover - defensive
+                    status = None
+            self.status_code = status or 0
+            headers = getattr(raw_response, "headers", {})
+            self.headers = dict(headers.items()) if hasattr(headers, "items") else dict(headers)
+
+        def close(self) -> None:
+            try:
+                self._raw.close()
+            except Exception:  # pragma: no cover - best effort cleanup
+                pass
+
+        @property
+        def content(self) -> bytes:
+            if self._content is None:
+                self._content = self._raw.read()
+                self.close()
+            return self._content
+
+        def json(self):  # type: ignore[override]
+            data = self.content
+            if not data:
+                return {}
+            return json.loads(data.decode("utf-8"))
+
+        def iter_content(self, chunk_size: Optional[int] = 8192):
+            if not chunk_size:
+                chunk_size = 8192
+            try:
+                while True:
+                    chunk = self._raw.read(chunk_size)
+                    if not chunk:
+                        break
+                    yield chunk
+            finally:
+                self.close()
+
+        def iter_lines(self, decode_unicode: bool = False):
+            buffer = b""
+            for chunk in self.iter_content(8192):
+                buffer += chunk
+                while b"\n" in buffer:
+                    line, buffer = buffer.split(b"\n", 1)
+                    if decode_unicode:
+                        yield line.decode("utf-8", errors="ignore")
+                    else:
+                        yield line
+            if buffer:
+                if decode_unicode:
+                    yield buffer.decode("utf-8", errors="ignore")
+                else:
+                    yield buffer
+
+    class _RequestsModule:
+        RequestException = _RequestException
+        Response = _SimpleResponse
+
+        @staticmethod
+        def request(
+            method: str,
+            url: str,
+            *,
+            headers: Optional[Dict[str, str]] = None,
+            json: Optional[dict] = None,
+            params: Optional[dict] = None,
+            stream: bool = False,
+            timeout: Optional[Tuple[float, float]] = None,
+            verify: Union[bool, str] = True,
+        ) -> _SimpleResponse:
+            del stream, verify  # streaming handled by response iterator; TLS verify defaults
+            headers = dict(headers or {})
+            data: Optional[bytes] = None
+            if json is not None:
+                headers.setdefault("Content-Type", "application/json")
+                data = json_module.dumps(json).encode("utf-8")
+
+            if params:
+                query = urllib_parse.urlencode(params)
+                separator = "&" if urllib_parse.urlparse(url).query else "?"
+                url = f"{url}{separator}{query}"
+
+            req = urllib_request.Request(url, data=data, headers=headers, method=method.upper())
+            timeout_value: Optional[float] = None
+            if isinstance(timeout, (tuple, list)) and timeout:
+                timeout_value = float(timeout[-1])
+            elif isinstance(timeout, (int, float)):
+                timeout_value = float(timeout)
+
+            try:
+                raw = urllib_request.urlopen(req, timeout=timeout_value)
+            except urllib_error.HTTPError as exc:
+                raw = exc
+            except urllib_error.URLError as exc:
+                raise _RequestException(str(exc)) from exc
+
+            return _SimpleResponse(raw)
+
+    # expose fallback under the ``requests`` name so the rest of the module works
+    requests = _RequestsModule()  # type: ignore
+    json_module = json
+else:
+    json_module = json
+
 from flask import (
     Flask,
     Response,
     jsonify,
     request,
+    send_file,
     send_from_directory,
     stream_with_context,
 )
@@ -58,9 +166,14 @@ DEFAULT_CONFIG = {
     "GENESIS_API_KEY": "",
     "OPENROUTER_API_KEY": "",
     "OPENROUTER_MODEL": "meta-llama/llama-3.1-8b-instruct",
+    "CORP_SSL_CERT_PATH": "",
     "VECTOR_INDEX_DIR": "./vectorstore",
+    "DESKTOP_EXPORT_DIR": str(Path.home() / "Desktop"),
+    "ICONS_DIR": "",
+    "USER_AVATAR_PATH": "",
     "EMBEDDING_MODEL": "text-embedding-3-small",
     "HTTP_TIMEOUT": 300,
+    "HTTP_PORT": 5000,
 }
 
 CONFIG_PATH = Path(__file__).with_name("config.json")
@@ -69,35 +182,62 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("monky.server")
 
 
-def load_config() -> Dict[str, str]:
-    """Load configuration from ``config.json`` and environment variables."""
+def load_config() -> Dict[str, Union[str, int]]:
+    if not CONFIG_PATH.exists():
+        raise FileNotFoundError("config.json not found. Run setup_wizard.py first.")
 
-    config: Dict[str, str] = dict(DEFAULT_CONFIG)
-    if CONFIG_PATH.exists():
-        try:
-            with CONFIG_PATH.open("r", encoding="utf-8") as fp:
-                data = json.load(fp)
-            if isinstance(data, dict):
-                for key, value in data.items():
-                    if value is None:
-                        continue
-                    config[key] = value
-        except Exception as exc:  # pragma: no cover - defensive coding
-            logger.warning("Failed to read config.json: %s", exc)
+    with CONFIG_PATH.open("r", encoding="utf-8") as fp:
+        data = json.load(fp) or {}
+    if not isinstance(data, dict):
+        raise ValueError("config.json must contain an object")
 
-    for key in list(config.keys()):
-        value = os.environ.get(key)
-        if value is not None:
-            config[key] = value
+    config: Dict[str, Union[str, int]] = dict(DEFAULT_CONFIG)
+    config.update({k: v for k, v in data.items() if v is not None})
 
-    # Normalise paths and derived values.
-    vector_dir = Path(config["VECTOR_INDEX_DIR"]).expanduser().resolve()
+    # Allow environment overrides for automation/testing.
+    for key in DEFAULT_CONFIG:
+        env_value = os.environ.get(key)
+        if env_value is not None:
+            config[key] = env_value
+
+    # Normalise numeric values.
+    try:
+        config["HTTP_PORT"] = int(config.get("HTTP_PORT", DEFAULT_CONFIG["HTTP_PORT"]))
+    except (TypeError, ValueError):
+        config["HTTP_PORT"] = DEFAULT_CONFIG["HTTP_PORT"]
+
+    try:
+        config["HTTP_TIMEOUT"] = int(config.get("HTTP_TIMEOUT", DEFAULT_CONFIG["HTTP_TIMEOUT"]))
+    except (TypeError, ValueError):
+        config["HTTP_TIMEOUT"] = DEFAULT_CONFIG["HTTP_TIMEOUT"]
+
+    # Normalise paths and expand user home references.
+    def _normalise_path(value: Union[str, int]) -> str:
+        if not value:
+            return ""
+        return str(Path(str(value)).expanduser())
+
+    vector_dir = Path(_normalise_path(config.get("VECTOR_INDEX_DIR", "")))
+    if not vector_dir.is_absolute():
+        vector_dir = (CONFIG_PATH.parent / vector_dir).resolve()
     config["VECTOR_INDEX_DIR"] = str(vector_dir)
+
+    for key in ("DESKTOP_EXPORT_DIR", "ICONS_DIR", "USER_AVATAR_PATH", "CORP_SSL_CERT_PATH"):
+        config[key] = _normalise_path(config.get(key, ""))
+
     return config
 
 
 app = Flask(__name__, static_folder=None)
-app.config["SETTINGS"] = load_config()
+app.config["JSON_SORT_KEYS"] = False
+
+try:
+    app.config["SETTINGS"] = load_config()
+    app.config["CONFIG_ERROR"] = None
+except Exception as exc:  # pragma: no cover - configuration errors handled at runtime
+    logger.warning("Configuration not ready: %s", exc)
+    app.config["SETTINGS"] = {}
+    app.config["CONFIG_ERROR"] = str(exc)
 
 
 # ---------------------------------------------------------------------------
@@ -105,12 +245,22 @@ app.config["SETTINGS"] = load_config()
 # ---------------------------------------------------------------------------
 
 
-def get_settings() -> Dict[str, str]:
-    return app.config["SETTINGS"]
+def configuration_error() -> Optional[str]:
+    return app.config.get("CONFIG_ERROR")
+
+
+def require_settings() -> Dict[str, Union[str, int]]:
+    error = configuration_error()
+    if error:
+        raise RuntimeError(error)
+    settings = app.config.get("SETTINGS")
+    if not isinstance(settings, dict) or not settings:
+        raise RuntimeError("Configuration not loaded")
+    return settings
 
 
 def choose_provider(preferred: Optional[str] = None) -> str:
-    settings = get_settings()
+    settings = require_settings()
     preferred = (preferred or "").lower() or None
 
     has_genesis = bool(settings.get("GENESIS_API_KEY"))
@@ -128,14 +278,13 @@ def choose_provider(preferred: Optional[str] = None) -> str:
 
 
 def build_headers(provider: str, extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
-    settings = get_settings()
+    settings = require_settings()
     headers: Dict[str, str] = {"Content-Type": "application/json"}
 
     if provider == "genesis":
         headers["Authorization"] = f"Bearer {settings['GENESIS_API_KEY']}"
     elif provider == "openrouter":
         headers["Authorization"] = f"Bearer {settings['OPENROUTER_API_KEY']}"
-        # These headers are recommended by OpenRouter but optional.
         headers.setdefault("HTTP-Referer", "http://localhost")
         headers.setdefault("X-Title", "MONKY Dashboard")
     else:  # pragma: no cover - defensive coding
@@ -147,12 +296,22 @@ def build_headers(provider: str, extra: Optional[Dict[str, str]] = None) -> Dict
 
 
 def provider_base_url(provider: str) -> str:
-    settings = get_settings()
+    settings = require_settings()
     if provider == "genesis":
-        return settings["GENESIS_BASE_URL"].rstrip("/")
+        return str(settings["GENESIS_BASE_URL"]).rstrip("/")
     if provider == "openrouter":
         return "https://openrouter.ai/api/v1"
     raise ValueError(f"Unknown provider: {provider}")
+
+
+def genesis_verify_option(settings: Dict[str, Union[str, int]]) -> Union[bool, str]:
+    env_override = os.environ.get("VERIFY_CERT")
+    if env_override and env_override.lower() in {"0", "false", "no"}:
+        return False
+    cert_path = str(settings.get("CORP_SSL_CERT_PATH") or "").strip()
+    if cert_path:
+        return cert_path
+    return True
 
 
 def upstream_request(
@@ -165,13 +324,16 @@ def upstream_request(
     stream: bool = False,
     headers: Optional[Dict[str, str]] = None,
 ) -> requests.Response:
-    """Forward a request to the specified provider."""
-
+    settings = require_settings()
     base_url = provider_base_url(provider)
     url = f"{base_url}{path}"
     merged_headers = build_headers(provider, headers)
 
-    timeout = (10, float(get_settings().get("HTTP_TIMEOUT", 300)))
+    timeout = (10, float(settings.get("HTTP_TIMEOUT", DEFAULT_CONFIG["HTTP_TIMEOUT"])))
+    verify: Union[bool, str] = True
+    if provider == "genesis":
+        verify = genesis_verify_option(settings)
+
     response = requests.request(
         method,
         url,
@@ -180,6 +342,7 @@ def upstream_request(
         params=params,
         stream=stream,
         timeout=timeout,
+        verify=verify,
     )
     return response
 
@@ -201,7 +364,6 @@ class RagIndex:
         self._loaded = False
         self._load_error: Optional[str] = None
 
-    # File name candidates recognised from the existing tooling.
     _INDEX_CANDIDATES = [
         "index.faiss",
         "faiss.index",
@@ -251,7 +413,7 @@ class RagIndex:
             return
 
         try:
-            if docs_path.suffix in {".json"}:
+            if docs_path.suffix == ".json":
                 with docs_path.open("r", encoding="utf-8") as fp:
                     metadata = json.load(fp)
             else:
@@ -284,23 +446,17 @@ class RagIndex:
         logger.info("Loaded FAISS index from %s", index_path)
 
     def _normalize_metadata(self, metadata) -> List[Dict[str, str]]:
-        """Return a list of dictionaries with ``text`` and ``source`` keys."""
-
         documents: List[Dict[str, str]] = []
 
         if isinstance(metadata, dict):
-            # Some vectorizers store documents in a mapping keyed by integer index
-            # or UUID.  Attempt to normalise common shapes.
             for key in sorted(metadata.keys()):
-                entry = metadata[key]
-                documents.append(self._extract_doc(entry))
+                documents.append(self._extract_doc(metadata[key]))
         elif isinstance(metadata, list):
             for entry in metadata:
                 documents.append(self._extract_doc(entry))
         else:
             logger.warning("Unsupported metadata format: %s", type(metadata))
 
-        # Filter out empty entries while preserving indices for FAISS results.
         cleaned: List[Dict[str, str]] = []
         for item in documents:
             if not item.get("text"):
@@ -343,7 +499,7 @@ class RagIndex:
         if query_vector is None:
             return []
 
-        if query_vector.ndim == 1:
+        if hasattr(query_vector, "ndim") and query_vector.ndim == 1:
             query_vector = query_vector.reshape(1, -1)
 
         query_vector = query_vector.astype("float32")
@@ -364,10 +520,17 @@ class RagIndex:
         return results
 
 
-rag_index = RagIndex(
-    Path(get_settings()["VECTOR_INDEX_DIR"]),
-    get_settings()["EMBEDDING_MODEL"],
-)
+_rag_index: Optional[RagIndex] = None
+
+
+def get_rag_index() -> RagIndex:
+    global _rag_index
+    settings = require_settings()
+    vector_dir = Path(str(settings.get("VECTOR_INDEX_DIR")))
+    embedding_model = str(settings.get("EMBEDDING_MODEL", DEFAULT_CONFIG["EMBEDDING_MODEL"]))
+    if _rag_index is None or _rag_index.index_dir != vector_dir or _rag_index.embedding_model_name != embedding_model:
+        _rag_index = RagIndex(vector_dir, embedding_model)
+    return _rag_index
 
 
 # ---------------------------------------------------------------------------
@@ -377,27 +540,55 @@ rag_index = RagIndex(
 
 @app.route("/")
 def serve_index() -> Response:
-    """Serve the single page application."""
-
+    error = configuration_error()
+    if error:
+        return Response(
+            f"Configuration error: {error}. Run setup_wizard.py first.",
+            status=500,
+            mimetype="text/plain",
+        )
     return send_from_directory(Path(__file__).parent, "index.html")
 
 
 @app.get("/health")
 def health() -> Response:
+    try:
+        require_settings()
+    except RuntimeError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 500
     return jsonify({"ok": True})
 
 
 @app.get("/env")
 def environment() -> Response:
-    settings = get_settings()
-    return jsonify(
-        {
-            "GENESIS_API_KEY": settings.get("GENESIS_API_KEY", ""),
-            "OPENROUTER_API_KEY": settings.get("OPENROUTER_API_KEY", ""),
-            "GENESIS_BASE_URL": settings.get("GENESIS_BASE_URL"),
-            "OPENROUTER_MODEL": settings.get("OPENROUTER_MODEL"),
-        }
-    )
+    try:
+        settings = require_settings()
+    except RuntimeError as exc:
+        return jsonify({"error": str(exc)}), 500
+
+    api_base = request.host_url.rstrip("/")
+    avatar_url = ""
+    avatar_path = str(settings.get("USER_AVATAR_PATH") or "").strip()
+    if avatar_path and Path(avatar_path).exists():
+        mtime = int(Path(avatar_path).stat().st_mtime)
+        avatar_url = f"/assets/avatar?v={mtime}"
+
+    payload = {
+        "API_BASE_URL": api_base,
+        "GENESIS_READY": bool(settings.get("GENESIS_API_KEY")),
+        "OPENROUTER_READY": bool(settings.get("OPENROUTER_API_KEY")),
+        "GENESIS_BASE_URL": settings.get("GENESIS_BASE_URL"),
+        "OPENROUTER_MODEL": settings.get("OPENROUTER_MODEL"),
+        "DEFAULT_MODEL": settings.get("OPENROUTER_MODEL"),
+        "VECTOR_INDEX_DIR": settings.get("VECTOR_INDEX_DIR"),
+        "DESKTOP_EXPORT_DIR": settings.get("DESKTOP_EXPORT_DIR"),
+        "ICONS_DIR": settings.get("ICONS_DIR"),
+        "ICONS_AVAILABLE": bool(settings.get("ICONS_DIR")),
+        "USER_AVATAR_URL": avatar_url,
+        "EMBEDDING_MODEL": settings.get("EMBEDDING_MODEL"),
+        "HTTP_PORT": settings.get("HTTP_PORT"),
+    }
+    return jsonify(payload)
 
 
 def relay_json_response(response: requests.Response) -> Response:
@@ -406,11 +597,46 @@ def relay_json_response(response: requests.Response) -> Response:
     return Response(data, status=response.status_code, content_type=content_type)
 
 
+@app.route("/icons/<path:filename>")
+def serve_icon(filename: str):
+    try:
+        settings = require_settings()
+    except RuntimeError:
+        return ("", 404)
+
+    icons_dir = str(settings.get("ICONS_DIR") or "").strip()
+    if not icons_dir:
+        return ("", 404)
+
+    directory = Path(icons_dir)
+    if not directory.exists():
+        return ("", 404)
+    return send_from_directory(directory, filename)
+
+
+@app.get("/assets/avatar")
+def serve_avatar():
+    try:
+        settings = require_settings()
+    except RuntimeError:
+        return ("", 404)
+
+    avatar_path = str(settings.get("USER_AVATAR_PATH") or "").strip()
+    if not avatar_path:
+        return ("", 404)
+
+    file_path = Path(avatar_path)
+    if not file_path.exists():
+        return ("", 404)
+
+    mimetype = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"
+    return send_file(file_path, mimetype=mimetype)
+
+
 @app.route("/api/models", methods=["GET"])
 def list_models() -> Response:
-    provider = request.args.get("provider")
     try:
-        provider = choose_provider(provider)
+        provider = choose_provider(request.args.get("provider"))
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -420,9 +646,8 @@ def list_models() -> Response:
 
 @app.route("/api/models/<model_id>", methods=["GET"])
 def get_model(model_id: str) -> Response:
-    provider = request.args.get("provider")
     try:
-        provider = choose_provider(provider)
+        provider = choose_provider(request.args.get("provider"))
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -433,9 +658,9 @@ def get_model(model_id: str) -> Response:
 @app.route("/api/embeddings", methods=["POST"])
 def embeddings() -> Response:
     payload = request.json or {}
-    provider = payload.get("provider") or request.args.get("provider")
+    provider_hint = payload.get("provider") or request.args.get("provider")
     try:
-        provider = choose_provider(provider)
+        provider = choose_provider(provider_hint)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -506,14 +731,13 @@ def chat_completions() -> Response:
         user_messages = [m for m in messages if m.get("role") == "user"]
         latest = user_messages[-1]["content"] if user_messages else ""
         try:
-            rag_matches = rag_index.query(latest, k=payload.get("rag_k", 5))
+            rag_matches = get_rag_index().query(latest, k=payload.get("rag_k", 5))
         except Exception as exc:
             logger.warning("RAG lookup failed: %s", exc)
             rag_matches = []
 
-    augmented_messages = augment_messages_with_rag(messages, rag_matches)
     outbound_payload = dict(payload)
-    outbound_payload["messages"] = augmented_messages
+    outbound_payload["messages"] = augment_messages_with_rag(messages, rag_matches)
 
     try:
         upstream = upstream_request(
@@ -523,7 +747,7 @@ def chat_completions() -> Response:
             json_payload=outbound_payload,
             stream=stream,
         )
-    except requests.RequestException as exc:
+    except requests.RequestException as exc:  # type: ignore[attr-defined]
         return jsonify({"error": str(exc)}), 502
 
     if stream:
@@ -535,7 +759,11 @@ def chat_completions() -> Response:
 
 
 def proxy_assistants_request(method: str, path: str, stream: bool = False) -> Response:
-    settings = get_settings()
+    try:
+        settings = require_settings()
+    except RuntimeError as exc:
+        return jsonify({"error": str(exc)}), 500
+
     if not settings.get("GENESIS_API_KEY"):
         return jsonify({"error": "Genesis credentials are required for this endpoint"}), 400
 
@@ -580,7 +808,11 @@ def threads_runs() -> Response:
 
 @app.route("/api/rag/stats", methods=["GET"])
 def rag_stats() -> Response:
-    return jsonify(rag_index.stats())
+    try:
+        stats = get_rag_index().stats()
+    except RuntimeError as exc:
+        return jsonify({"hasIndex": False, "docCount": 0, "indexPath": "", "error": str(exc)})
+    return jsonify(stats)
 
 
 @app.route("/api/rag/query", methods=["POST"])
@@ -589,7 +821,7 @@ def rag_query() -> Response:
     query = payload.get("q") or ""
     k = int(payload.get("k") or 5)
     try:
-        results = rag_index.query(query, k=k)
+        results = get_rag_index().query(query, k=k)
     except Exception as exc:
         return jsonify({"error": str(exc), "matches": []}), 500
 
@@ -602,8 +834,13 @@ def rag_query() -> Response:
 
 
 def main() -> None:
+    error = configuration_error()
+    if error:
+        raise SystemExit(f"{error}")
+
+    settings = require_settings()
     host = os.environ.get("PROXY_HOST", "127.0.0.1")
-    port = int(os.environ.get("PROXY_PORT", "5000"))
+    port = int(os.environ.get("PROXY_PORT", settings.get("HTTP_PORT", 5000)))
     debug = os.environ.get("FLASK_DEBUG", "0") == "1"
     app.run(host=host, port=port, debug=debug)
 

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -1,0 +1,203 @@
+"""Interactive first-run wizard for configuring the MONKY dashboard."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+CONFIG_SCHEMA = {
+    "GENESIS_BASE_URL": "https://api.ai.us.lmco.com/v1",
+    "GENESIS_API_KEY": "",
+    "OPENROUTER_API_KEY": "",
+    "OPENROUTER_MODEL": "meta-llama/llama-3.1-8b-instruct",
+    "CORP_SSL_CERT_PATH": "",
+    "VECTOR_INDEX_DIR": "./vectorstore",
+    "DESKTOP_EXPORT_DIR": str(Path.home() / "Desktop"),
+    "ICONS_DIR": "",
+    "USER_AVATAR_PATH": "",
+    "EMBEDDING_MODEL": "text-embedding-3-small",
+    "HTTP_TIMEOUT": 300,
+    "HTTP_PORT": 5000,
+}
+
+BASE_DIR = Path(__file__).resolve().parent
+CONFIG_PATH = BASE_DIR / "config.json"
+
+
+def load_existing_config() -> dict:
+    if not CONFIG_PATH.exists():
+        return dict(CONFIG_SCHEMA)
+    try:
+        with CONFIG_PATH.open("r", encoding="utf-8") as fp:
+            data = json.load(fp) or {}
+        if not isinstance(data, dict):
+            raise ValueError("Invalid configuration format")
+        existing = dict(CONFIG_SCHEMA)
+        existing.update({k: v for k, v in data.items() if v is not None})
+        return existing
+    except Exception as exc:
+        messagebox.showwarning("MONKY Setup", f"Existing config could not be read: {exc}")
+        return dict(CONFIG_SCHEMA)
+
+
+class SetupWizard(ttk.Frame):
+    def __init__(self, master: tk.Tk):
+        super().__init__(master, padding=20)
+        self.master = master
+        self.grid(sticky="nsew")
+        master.title("MONKY Setup Wizard")
+        master.geometry("640x560")
+        master.minsize(620, 520)
+
+        self.columnconfigure(1, weight=1)
+        master.columnconfigure(0, weight=1)
+        master.rowconfigure(0, weight=1)
+
+        self.vars = {
+            "GENESIS_API_KEY": tk.StringVar(),
+            "GENESIS_BASE_URL": tk.StringVar(value=CONFIG_SCHEMA["GENESIS_BASE_URL"]),
+            "OPENROUTER_API_KEY": tk.StringVar(),
+            "OPENROUTER_MODEL": tk.StringVar(value=CONFIG_SCHEMA["OPENROUTER_MODEL"]),
+            "CORP_SSL_CERT_PATH": tk.StringVar(),
+            "VECTOR_INDEX_DIR": tk.StringVar(value=CONFIG_SCHEMA["VECTOR_INDEX_DIR"]),
+            "DESKTOP_EXPORT_DIR": tk.StringVar(value=CONFIG_SCHEMA["DESKTOP_EXPORT_DIR"]),
+            "ICONS_DIR": tk.StringVar(),
+            "USER_AVATAR_PATH": tk.StringVar(),
+            "HTTP_PORT": tk.StringVar(value=str(CONFIG_SCHEMA["HTTP_PORT"])),
+        }
+
+        ttk.Label(self, text="Configure MONKY", font=("Segoe UI", 16, "bold")).grid(row=0, column=0, columnspan=3, pady=(0, 20), sticky="w")
+
+        row = 1
+        row = self._add_entry(row, "Genesis API key", "GENESIS_API_KEY")
+        row = self._add_entry(row, "Genesis base URL", "GENESIS_BASE_URL")
+        row = self._add_entry(row, "OpenRouter API key", "OPENROUTER_API_KEY")
+        row = self._add_entry(row, "OpenRouter default model", "OPENROUTER_MODEL")
+        row = self._add_file_chooser(row, "Corporate SSL cert", "CORP_SSL_CERT_PATH", filetypes=[("Certificate", "*.pem *.crt"), ("All files", "*.*")])
+        row = self._add_directory_chooser(row, "Vector index directory", "VECTOR_INDEX_DIR")
+        row = self._add_directory_chooser(row, "Desktop export directory", "DESKTOP_EXPORT_DIR")
+        row = self._add_directory_chooser(row, "Custom icons directory", "ICONS_DIR", required=False)
+        row = self._add_file_chooser(row, "User avatar image", "USER_AVATAR_PATH", filetypes=[("Images", "*.png *.jpg *.jpeg *.gif"), ("All files", "*.*")], required=False)
+        row = self._add_entry(row, "HTTP port", "HTTP_PORT")
+
+        note = ttk.Label(
+            self,
+            text="Configuration is stored locally in config.json. Secrets remain on your machine.",
+            foreground="#5e6c94",
+            wraplength=560,
+            justify="left",
+        )
+        note.grid(row=row, column=0, columnspan=3, pady=(12, 6), sticky="w")
+
+        button_frame = ttk.Frame(self)
+        button_frame.grid(row=row + 1, column=0, columnspan=3, sticky="e", pady=(10, 0))
+        ttk.Button(button_frame, text="Cancel", command=self.master.destroy).grid(row=0, column=0, padx=(0, 8))
+        ttk.Button(button_frame, text="Finish", command=self.finish).grid(row=0, column=1)
+
+        self._load_defaults()
+
+    def _add_entry(self, row: int, label: str, key: str) -> int:
+        ttk.Label(self, text=label).grid(row=row, column=0, sticky="w", pady=4)
+        entry = ttk.Entry(self, textvariable=self.vars[key])
+        entry.grid(row=row, column=1, columnspan=2, sticky="ew", padx=(8, 0))
+        return row + 1
+
+    def _add_file_chooser(self, row: int, label: str, key: str, *, filetypes=None, required: bool = True) -> int:
+        ttk.Label(self, text=label).grid(row=row, column=0, sticky="w", pady=4)
+        entry = ttk.Entry(self, textvariable=self.vars[key])
+        entry.grid(row=row, column=1, sticky="ew", padx=(8, 0))
+        ttk.Button(
+            self,
+            text="Browse…",
+            command=lambda: self._browse_file(key, filetypes=filetypes, required=required),
+        ).grid(row=row, column=2, padx=(8, 0))
+        return row + 1
+
+    def _add_directory_chooser(self, row: int, label: str, key: str, required: bool = True) -> int:
+        ttk.Label(self, text=label).grid(row=row, column=0, sticky="w", pady=4)
+        entry = ttk.Entry(self, textvariable=self.vars[key])
+        entry.grid(row=row, column=1, sticky="ew", padx=(8, 0))
+        ttk.Button(
+            self,
+            text="Browse…",
+            command=lambda: self._browse_directory(key, required=required),
+        ).grid(row=row, column=2, padx=(8, 0))
+        return row + 1
+
+    def _browse_file(self, key: str, *, filetypes=None, required: bool = True) -> None:
+        initialdir = Path(self.vars[key].get() or Path.home()).expanduser()
+        filename = filedialog.askopenfilename(parent=self.master, filetypes=filetypes, initialdir=initialdir)
+        if filename:
+            self.vars[key].set(filename)
+        elif required:
+            self.vars[key].set("")
+
+    def _browse_directory(self, key: str, *, required: bool = True) -> None:
+        initialdir = Path(self.vars[key].get() or Path.home()).expanduser()
+        directory = filedialog.askdirectory(parent=self.master, initialdir=initialdir)
+        if directory:
+            self.vars[key].set(directory)
+        elif required:
+            self.vars[key].set("")
+
+    def _load_defaults(self) -> None:
+        config = load_existing_config()
+        for key, var in self.vars.items():
+            value = config.get(key, "")
+            if value is None:
+                value = ""
+            var.set(str(value))
+
+    def finish(self) -> None:
+        values = {key: var.get().strip() for key, var in self.vars.items()}
+
+        try:
+            port = int(values["HTTP_PORT"] or CONFIG_SCHEMA["HTTP_PORT"])
+            if not (1 <= port <= 65535):
+                raise ValueError
+        except ValueError:
+            messagebox.showerror("MONKY Setup", "HTTP port must be a number between 1 and 65535.")
+            return
+
+        values["HTTP_PORT"] = port
+        config = dict(CONFIG_SCHEMA)
+        config.update(values)
+
+        try:
+            with CONFIG_PATH.open("w", encoding="utf-8") as fp:
+                json.dump(config, fp, indent=2)
+        except Exception as exc:
+            messagebox.showerror("MONKY Setup", f"Failed to write config.json: {exc}")
+            return
+
+        if messagebox.askyesno("MONKY Setup", "Configuration saved. Launch MONKY now?", default=messagebox.YES):
+            self.launch_monky()
+        self.master.destroy()
+
+    def launch_monky(self) -> None:
+        launcher = BASE_DIR / "launch_monky.py"
+        if not launcher.exists():
+            messagebox.showerror("MONKY Setup", "launch_monky.py not found")
+            return
+        try:
+            subprocess.Popen([sys.executable, str(launcher)], cwd=str(BASE_DIR))
+        except Exception as exc:
+            messagebox.showerror("MONKY Setup", f"Unable to start MONKY: {exc}")
+
+
+def main() -> None:
+    root = tk.Tk()
+    try:
+        ttk.Style().theme_use("clam")
+    except tk.TclError:
+        pass
+    SetupWizard(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - script execution
+    main()


### PR DESCRIPTION
## Summary
- add a tkinter setup wizard that captures MONKY configuration values, writes config.json, and launches the dashboard
- create a headless launcher that starts the Flask proxy, waits for the /health endpoint, and opens the dashboard URL
- expand the Flask server with stricter config loading, optional icon/avatar serving, sanitized /env metadata, and RAG-friendly endpoints
- refresh the dashboard UI with server status polling, server/storage tooling, avatar overrides, and optional icon packs
- document runtime dependencies including optional FAISS support

## Testing
- python -m compileall setup_wizard.py launch_monky.py server.py

------
https://chatgpt.com/codex/tasks/task_e_68cec28dc48c832c87fb792944a94c30